### PR TITLE
fix bug 1143743; add option for https clones

### DIFF
--- a/config.go
+++ b/config.go
@@ -20,6 +20,7 @@ var Config struct {
 		Token   string
 		Secret  string
 	}
+	HttpsClone bool
 }
 
 func init() {
@@ -100,6 +101,12 @@ func InitConfig() {
 				log.Fatal(err)
 			}
 		}
+	}
+
+	// Parse clone style (git or https)
+	Config.HttpsClone, err = c.GetBool("", "httpsclone")
+	if err != nil && err.(goconf.GetError).Reason != goconf.OptionNotFound {
+		log.Fatal(err)
 	}
 
 }

--- a/deadci.ini
+++ b/deadci.ini
@@ -27,6 +27,8 @@ port = 80
 # Uncomment to enable a custom hostname.
 #host = example.com
 
+# By default git clones will use git+ssh. Set to true to use https clones.
+#httpsclone = true
 
 [github]
 

--- a/event.go
+++ b/event.go
@@ -63,6 +63,9 @@ func (e *Event) Run() (string, error) {
 
 	// Clone repo
 	cmdClone := exec.Command("git", "clone", "git@"+e.Domain+":"+e.Owner+"/"+e.Repo+".git")
+	if Config.HttpsClone == true {
+		cmdClone = exec.Command("git", "clone", "https://"+e.Domain+"/"+e.Owner+"/"+e.Repo+".git")
+	}
 	cmdClone.Dir = Config.TempDir + "/deadci/" + e.Path()
 	cmdCloneOut, err := cmdClone.CombinedOutput()
 	e.Log = append(e.Log, cmdCloneOut...)


### PR DESCRIPTION
This addresses a use case that we have at Mozilla.
